### PR TITLE
Fixing generated reference tags in element links

### DIFF
--- a/redactori/resources/js/RedactorIInput.js
+++ b/redactori/resources/js/RedactorIInput.js
@@ -272,7 +272,8 @@ Craft.RedactorIInput = Garnish.Base.extend(
 					{
 						this.redactor.selection.restore();
 						var element   = elements[0],
-							url       = element.url+'#'+settings.elementType.toLowerCase()+':'+element.id,
+							elementTypeHandle = settings.elementType.replace(/^\w|_\w/g, function (match) { return match.toLowerCase(); }),
+							url       = element.url+'#'+elementTypeHandle+':'+element.id,
 							selection = this.redactor.selection.getText(),
 							title = selection.length > 0 ? selection : element.label;
 						this.redactor.insert.node($('<a href="'+url+'">'+title+'</a>')[0]);


### PR DESCRIPTION
The old way of working out the element type handle by just lowercasing it didn’t take into account camel cased Element Type handles. These two lined are nicked from [`RichTextInput.js`](https://github.com/pixelandtonic/Craft-Release/blob/master/app/resources/js/RichTextInput.js#L354-L355) in the Craft core.
